### PR TITLE
[bugfix][ChromXControlEngine][Submodule] fixed MicroPIDValue type to …

### DIFF
--- a/include/CCE_ChromXItem/CCETestDataDevice.h
+++ b/include/CCE_ChromXItem/CCETestDataDevice.h
@@ -26,7 +26,7 @@ public:
     quint16 getCOLUMNTemperature();
 
     quint16 readMicroPIDValue(bool sync=true, int msec=CCE_Defalut_SyncTimeout);
-    quint16 getMicroPIDValue();
+    quint32 getMicroPIDValue();
 
     quint16 readAllInfo(bool sync=true, int msec=CCE_Defalut_SyncTimeout);
     STestData getAllInfo();

--- a/include/CCE_CommunicatEngine/CCEInteCtrlPackageStruct.h
+++ b/include/CCE_CommunicatEngine/CCEInteCtrlPackageStruct.h
@@ -863,11 +863,11 @@ typedef struct tagTestData{
     quint16 TICurTemperature;       //0x0002-0x0003	R/	TI 当前温度数值 	(0-65535)
     quint32 curTestRunTime;         //0x0004-0x0007	R/	当前测试运行的时间 （0.01s）	(32bit)
     quint16 COLUMNTemperature;      //0x0008-0x0009	R/	COLUMN 温度转换数值  	(0-65535)
-    quint16 MicroPIDValue;          //0x000a-0x000d	R/	PID/HDPID 当前的ADC读数 	(32bit)
+    quint32 MicroPIDValue;          //0x000a-0x000d	R/	PID/HDPID 当前的ADC读数 	(32bit)
 
     tagTestData()
     {
-        Q_ASSERT(sizeof(tagTestData) == 12);
+        Q_ASSERT(sizeof(tagTestData) == 14);
         clear();
     }
     void clear()
@@ -894,7 +894,7 @@ typedef struct tagTestData{
         TICurTemperature =  CCEUIHelper::bigLittleSwap16(TICurTemperature);
         curTestRunTime =    CCEUIHelper::bigLittleSwap32(curTestRunTime);
         COLUMNTemperature = CCEUIHelper::bigLittleSwap16(COLUMNTemperature);
-        MicroPIDValue =     CCEUIHelper::bigLittleSwap16(MicroPIDValue);
+        MicroPIDValue =     CCEUIHelper::bigLittleSwap32(MicroPIDValue);
     }
 
     QVariant getModelData(int col) const{

--- a/include/CCE_CommunicatEngine/CCESingleStatusPackage.h
+++ b/include/CCE_CommunicatEngine/CCESingleStatusPackage.h
@@ -95,7 +95,7 @@ class CCE_COMMUNICATENGINE_EXPORT CCESingleStatusPackage_ReadMicroPIDValue : pub
 {
     CCE_DECLARE_PACKAGECONSTRUCTOR(CCESingleStatusPackage_ReadMicroPIDValue, CCEAbstractSingleStatusPackage)
 public:
-    quint16 getValue() const;
+    quint32 getValue() const;
 protected:
     EFrameType CmdFrameType () const override {
         return EFrameType::EFT_ReadFrame;

--- a/include/CCE_CommunicatEngine/CCETestDataPackage.h
+++ b/include/CCE_CommunicatEngine/CCETestDataPackage.h
@@ -115,7 +115,7 @@ class CCE_COMMUNICATENGINE_EXPORT CCETestDataPackage_ReadMicroPIDValue : public 
 {
     CCE_DECLARE_PACKAGECONSTRUCTOR(CCETestDataPackage_ReadMicroPIDValue, CCEAbstractTestDataPackage)
 public:
-    quint16 getValue() const;
+    quint32 getValue() const;
 protected:
     EFrameType CmdFrameType () const override {
         return EFrameType::EFT_ReadFrame;
@@ -124,7 +124,7 @@ protected:
         return quint16(ECommand::EC_Read_MicroPIDValue);
     }
     QByteArray CmdContent() const override{
-     return QByteArray().fill(0,2);
+     return QByteArray().fill(0,4);
     }
 };
 

--- a/src/CCE_ChromXItem/CCETestDataDevice.cpp
+++ b/src/CCE_ChromXItem/CCETestDataDevice.cpp
@@ -89,7 +89,7 @@ quint16 CCETestDataDevice::readMicroPIDValue(bool sync, int msec)
     CCE_DECLARE_COMMANDSEND(d_ptr,pack);
 }
 
-quint16 CCETestDataDevice::getMicroPIDValue()
+quint32 CCETestDataDevice::getMicroPIDValue()
 {
     Q_D(CCETestDataDevice);
     return d->m_testData.MicroPIDValue;
@@ -112,8 +112,8 @@ STestData CCETestDataDevice::getAllInfo()
 void CCETestDataDevice::registerCallBack()
 {
     Q_D(CCETestDataDevice);
-    d->m_packageMgr.registerPackage(CCETestDataPackage_ReadTDCurTemperature(),
-                                        std::bind(&CCETestDataDevice::onParseReadTDCurTemperature,this,std::placeholders::_1));
+//    d->m_packageMgr.registerPackage(CCETestDataPackage_ReadTDCurTemperature(),
+//                                        std::bind(&CCETestDataDevice::onParseReadTDCurTemperature,this,std::placeholders::_1));
     d->m_packageMgr.registerPackage(CCETestDataPackage_ReadTICurTemperature(),
                                         std::bind(&CCETestDataDevice::onParseReadTICurTemperature,this,std::placeholders::_1));
     d->m_packageMgr.registerPackage(CCETestDataPackage_ReadCurTestRunTime(),

--- a/src/CCE_CommunicatEngine/Protocol/SingleStatus/CCESingleStatusPackage.cpp
+++ b/src/CCE_CommunicatEngine/Protocol/SingleStatus/CCESingleStatusPackage.cpp
@@ -31,9 +31,9 @@ quint16 CCESingleStatusPackage_ReadCOLUMNTemperature::getCurTemperature() const
     DO_GETUSHORTRESULT(getContent());
 }
 
-quint16 CCESingleStatusPackage_ReadMicroPIDValue::getValue() const
+quint32 CCESingleStatusPackage_ReadMicroPIDValue::getValue() const
 {
-    DO_GETUSHORTRESULT(getContent());
+    DO_GETUINTRESULT(getContent());
 }
 
 quint16 CCESingleStatusPackage_ReadEPCPressure::getValue() const

--- a/src/CCE_CommunicatEngine/Protocol/TestData/CCETestDataPackage.cpp
+++ b/src/CCE_CommunicatEngine/Protocol/TestData/CCETestDataPackage.cpp
@@ -36,9 +36,9 @@ quint16 CCETestDataPackage_ReadCOLUMNTemperature::getCurTemperature() const
     DO_GETUSHORTRESULT(getContent());
 }
 
-quint16 CCETestDataPackage_ReadMicroPIDValue::getValue() const
+quint32 CCETestDataPackage_ReadMicroPIDValue::getValue() const
 {
-    DO_GETUSHORTRESULT(getContent());
+    DO_GETUINTRESULT(getContent());
 }
 
 STestData CCETestDataPackage_ReadAllInfo::getInfo() const


### PR DESCRIPTION
…quint32

[what] 1、修复Micro PID的值类型为quint32

[why] 之前写错了

[how]