### PR TITLE
[bugfix][ChromXControlEngine][InteCtrlPackage] Fixed microPID data ty…

### DIFF
--- a/src/CCE_Core/CCEUIHelper.cpp
+++ b/src/CCE_Core/CCEUIHelper.cpp
@@ -678,7 +678,7 @@ quint16 CCEUIHelper::temperToResistance(double temper)
 
 double CCEUIHelper::getMicroPIDUiValue(quint32 transValue)
 {
-    return (transValue * 5 / 2147483647);
+    return ((double)transValue * 5 / 2147483647);
 }
 
 QByteArray CCEUIHelper::intToByte(int i)


### PR DESCRIPTION
…pe and conversion problems

[what] 1、microPIDValue由 quint16 改为 quint32，对应修改UIHelper中的数据转换公式

[why]

[how]

Signed-off-by: Feric0504 <1401507264@qq.com>